### PR TITLE
Fix notice if comment is not set. Fix announce-list not conforming to spec

### DIFF
--- a/src/TorrentFile.php
+++ b/src/TorrentFile.php
@@ -89,7 +89,7 @@ class TorrentFile
     public function setAnnounceList(array $announceList): self
     {
         if (count($announceList)) {
-            $this->data['announce-list'] = array_values($announceList);
+            $this->data['announce-list'] = array_chunk($announceList);
         } else {
             unset($this->data['announce-list']);
         }
@@ -121,7 +121,7 @@ class TorrentFile
 
     public function getComment(): ?string
     {
-        return $this->data['comment'];
+        return isset($this->data['comment']);
     }
 
     public function setCreatedBy(string $comment): self


### PR DESCRIPTION
Replace $this->data['announce-list'] = array_values($announceList); to $this->data['announce-list'] = array_chunk($announceList); resolve announce-list
Replace return $this->data['comment']; to return isset($this->data['comment']); Resolve comment